### PR TITLE
Fixes 2

### DIFF
--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -175,7 +175,16 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 		switch (mode) {
 			case "brush":
 			case "eraser": {
-				currentPath2D.current.lineTo(floorX, floorY);
+			const lastPoint = currentPath.current[currentPath.current.length - 1];
+				const midPointX = lastPoint.x + (floorX - lastPoint.x) / 2;
+				const midPointY = lastPoint.y + (floorY - lastPoint.y) / 2;
+				
+        currentPath2D.current.quadraticCurveTo(
+          lastPoint.x,
+          lastPoint.y,
+          midPointX,
+          midPointY
+        );
 				ctx.stroke(currentPath2D.current);
 
 				currentPath.current.push({

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -30,7 +30,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 		shape,
 		width,
 		height,
-		dpi,
+		drawPaperCanvas,
 		changeMode,
 		changeColor,
 		createElement,
@@ -52,7 +52,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 			getActiveLayer: state.getActiveLayer,
 			pushHistory: state.pushHistory,
 			getPointerPosition: state.getPointerPosition,
-			drawCanvas: state.drawCanvas,
+			drawPaperCanvas: state.drawPaperCanvas,
 			centerCanvas: state.centerCanvas
 		}))
 	);
@@ -153,30 +153,13 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 		const floorX = Math.floor(x);
 		const floorY = Math.floor(y);
 
-		ctx.fillStyle = color.current;
-		ctx.lineWidth = strokeWidth.current;
-		ctx.lineCap = "round";
-		ctx.globalAlpha = opacity.current;
-		ctx.strokeStyle = color.current;
-		ctx.globalCompositeOperation =
-			mode === "eraser" ? "destination-out" : "source-over";
-
 		const currentShapeMode = shapeMode.current;
 
 		switch (mode) {
 			case "brush":
 			case "eraser": {
 				if (!onCanvas) return;
-				// redrawCanvas();
-
-				// for (let i = 0; i < currentPath.current.length; i++) {
-				// 	const point = currentPath.current[i];
-				// 	if (point.startingPoint) {
-				// 		currentPath2D.current.moveTo(point.x, point.y);
-				// 	} else {
-				// 		currentPath2D.current.lineTo(point.x, point.y);
-				// 	}
-				// }
+				redrawCanvas();
 
 				currentPath2D.current.lineTo(floorX, floorY);
 				ctx.stroke(currentPath2D.current);
@@ -186,6 +169,8 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 					y: floorY,
 					startingPoint: false
 				});
+
+				drawPaperCanvas(ctx, 0, 0);
 				break;
 			}
 

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -153,20 +153,30 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 		const floorX = Math.floor(x);
 		const floorY = Math.floor(y);
 
+		ctx.fillStyle = color.current;
+		ctx.lineWidth = strokeWidth.current;
+		ctx.lineCap = "round";
+		ctx.globalAlpha = opacity.current;
+		ctx.strokeStyle = color.current;
 		ctx.globalCompositeOperation =
 			mode === "eraser" ? "destination-out" : "source-over";
-		ctx.fillStyle = color.current;
-		ctx.strokeStyle = color.current;
-		ctx.lineWidth = strokeWidth.current * dpi;
+
 		const currentShapeMode = shapeMode.current;
 
 		switch (mode) {
 			case "brush":
 			case "eraser": {
 				if (!onCanvas) return;
-				ctx.lineWidth = strokeWidth.current * dpi;
-				ctx.lineCap = "round";
-				ctx.lineJoin = "round";
+				// redrawCanvas();
+
+				// for (let i = 0; i < currentPath.current.length; i++) {
+				// 	const point = currentPath.current[i];
+				// 	if (point.startingPoint) {
+				// 		currentPath2D.current.moveTo(point.x, point.y);
+				// 	} else {
+				// 		currentPath2D.current.lineTo(point.x, point.y);
+				// 	}
+				// }
 
 				currentPath2D.current.lineTo(floorX, floorY);
 				ctx.stroke(currentPath2D.current);
@@ -176,7 +186,6 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 					y: floorY,
 					startingPoint: false
 				});
-				// drawCanvas(activeLayer);
 				break;
 			}
 

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -1,28 +1,40 @@
 // Lib
-import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import {
+	forwardRef,
+	useEffect,
+	useImperativeHandle,
+	useMemo,
+	useRef
+} from "react";
 import { parseColor } from "react-aria-components";
 import { useShallow } from "zustand/react/shallow";
 import useStoreSubscription from "@/state/hooks/useStoreSubscription";
 import useStore from "@/state/hooks/useStore";
-
-// Types
-import type { MouseEvent as ReactMouseEvent } from "react";
-import { type Coordinates, CanvasElementPath } from "@/types";
 import useThrottle from "@/state/hooks/useThrottle";
 import useCanvasRedrawListener from "@/state/hooks/useCanvasRedrawListener";
 import useCanvasRef from "@/state/hooks/useCanvasRef";
 import { redrawCanvas } from "@/lib/utils";
+import ElementsStore from "@/state/stores/ElementsStore";
+import LayersStore from "@/state/stores/LayersStore";
+import ImageElementStore from "@/state/stores/ImageElementStore";
 
-// Styles using Tailwind
+// Types
+import type {
+	Dispatch,
+	MouseEvent as ReactMouseEvent,
+	SetStateAction
+} from "react";
+import { type Coordinates, CanvasElementPath } from "@/types";
+import useStoreContext from "@/state/hooks/useStoreContext";
 
 type CanvasProps = {
-	isGrabbing: boolean;
+	setLoading: Dispatch<SetStateAction<boolean>>;
 };
 
 const THROTTLE_DELAY_MS = 10; // milliseconds
 
 const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
-	{ isGrabbing },
+	{ setLoading },
 	ref
 ) {
 	const {
@@ -37,7 +49,9 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 		getActiveLayer,
 		pushHistory,
 		getPointerPosition,
-		centerCanvas
+		centerCanvas,
+		setElements,
+		setLayers
 	} = useStore(
 		useShallow((state) => ({
 			mode: state.mode,
@@ -53,14 +67,15 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 			pushHistory: state.pushHistory,
 			getPointerPosition: state.getPointerPosition,
 			drawPaperCanvas: state.drawPaperCanvas,
-			centerCanvas: state.centerCanvas
+			centerCanvas: state.centerCanvas,
+			setElements: state.setElements,
+			setLayers: state.setLayers
 		}))
 	);
+	const store = useStoreContext();
 	const { setRef } = useCanvasRef();
 	const color = useStoreSubscription((state) => state.color);
-	const strokeWidth = useStoreSubscription((state) => state.strokeWidth);
 	const shapeMode = useStoreSubscription((state) => state.shapeMode);
-	const opacity = useStoreSubscription((state) => state.opacity);
 
 	const isDrawing = useRef<boolean>(false);
 	const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -79,7 +94,11 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 
 		const canvas = e.currentTarget;
 
-		if (!canvas) throw new Error("No active layer found. This is a bug.");
+		const onCanvas = e.target === canvas || canvas.contains(e.target as Node);
+
+		if (!onCanvas) {
+			return;
+		}
 
 		const ctx = canvas.getContext("2d", {
 			willReadFrequently: true
@@ -88,13 +107,6 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 		if (!ctx) {
 			throw new Error("Couldn't get the 2D context of the canvas.");
 		}
-
-		ctx.globalAlpha = mode === "eraser" ? 1 : opacity.current;
-
-		// Clip the drawing to the bounds of the canvas
-		ctx.save();
-		ctx.rect(0, 0, width, height);
-		ctx.clip();
 
 		// Calculate the position of the mouse relative to the canvas.
 		const { x, y } = getPointerPosition(canvas, e.clientX, e.clientY);
@@ -112,7 +124,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 			currentPath2D.current.moveTo(floorX, floorY);
 			// Save the current path.
 			currentPath.current.push({ x: floorX, y: floorY, startingPoint: true });
-		} else if (mode === "eye_drop" && !isGrabbing) {
+		} else if (mode === "eye_drop") {
 			// `getPointerPosition` gives us the position in world coordinates,
 			// but we need the position in canvas coordinates for `getImageData`.
 			const rect = canvas.getBoundingClientRect();
@@ -138,7 +150,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 
 		const onCanvas = e.target === canvas || canvas.contains(e.target as Node);
 
-		if (e.buttons !== 1 || !isDrawing.current || isGrabbing) {
+		if (e.buttons !== 1 || !isDrawing.current || !onCanvas) {
 			return;
 		}
 		if (mode === "shapes" || !currentPath2D.current) {
@@ -155,12 +167,14 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 
 		const currentShapeMode = shapeMode.current;
 
+		redrawCanvas();
+		ctx.save();
+		ctx.rect(0, 0, width, height);
+		ctx.clip();
+
 		switch (mode) {
 			case "brush":
 			case "eraser": {
-				if (!onCanvas) return;
-				redrawCanvas();
-
 				currentPath2D.current.lineTo(floorX, floorY);
 				ctx.stroke(currentPath2D.current);
 
@@ -175,7 +189,6 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 			}
 
 			case "shapes": {
-				redrawCanvas();
 				if (shape === "circle") {
 					const width = x - initialPosition.current.x;
 					const height = y - initialPosition.current.y;
@@ -234,23 +247,27 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 				break;
 			}
 		}
+		ctx.restore();
 	}, THROTTLE_DELAY_MS);
 
 	// Handler for when the mouse is moved on the canvas.
 	// This should handle a majority of the drawing process.
 
 	const onMouseUp = (e: ReactMouseEvent<HTMLCanvasElement>) => {
-		if (isGrabbing) return;
 		isDrawing.current = false;
 
 		const activeLayer = getActiveLayer();
 		const canvas = e.currentTarget;
 
+		const onCanvas = e.target === canvas || canvas.contains(e.target as Node);
+
+		if (!onCanvas || activeLayer.hidden) {
+			return;
+		}
+
 		const ctx = canvas.getContext("2d");
 
 		if (!ctx) throw new Error("Couldn't get the 2D context of the canvas.");
-
-		ctx.restore();
 
 		const { x, y } = getPointerPosition(canvas, e.clientX, e.clientY);
 		const { x: initX, y: initY } = initialPosition.current;
@@ -298,7 +315,9 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 
 	useImperativeHandle(ref, () => canvasRef.current!, []);
 
-	useCanvasRedrawListener(canvasRef);
+	const debounceRedraw = useMemo(() => false, []);
+
+	useCanvasRedrawListener(canvasRef, undefined, debounceRedraw);
 
 	useEffect(() => {
 		document.addEventListener("mousemove", onMouseMove);
@@ -311,8 +330,45 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
 		const ref = canvasRef.current;
 		if (!ref) return;
 
-		centerCanvas(ref);
-	}, [centerCanvas]);
+		const persistStoreName = store.persist.getOptions().name;
+
+		if (!persistStoreName) return;
+
+		const savedStateExists = localStorage.getItem(persistStoreName) !== null;
+
+		if (!savedStateExists) {
+			centerCanvas(ref);
+		}
+	}, [centerCanvas, store]);
+
+	useEffect(() => {
+		async function updateLayersAndElements() {
+			const elements = await ElementsStore.getElements();
+			const layers = await LayersStore.getLayers();
+			await ImageElementStore.loadImages();
+
+			// There must always be at least one layer.
+			// If there are no layers, do not update,
+			// and instead use the default layer state.
+			if (layers.length > 0) {
+				setLayers(
+					layers
+						.sort((a, b) => a[1].position - b[1].position)
+						.map(([id, { name }], i) => ({
+							name,
+							id,
+							active: i === 0,
+							hidden: false
+						}))
+				);
+			}
+			setElements(elements.map(([, element]) => element));
+			setLoading(false);
+			redrawCanvas();
+		}
+
+		updateLayersAndElements();
+	}, [setElements, setLayers, setLoading]);
 
 	return (
 		<canvas

--- a/src/components/CanvasPane/CanvasPane.tsx
+++ b/src/components/CanvasPane/CanvasPane.tsx
@@ -192,6 +192,7 @@ function CanvasPane({ loading }: CanvasPaneProps): ReactNode {
 			if (e instanceof WheelEvent) {
 				if (e.ctrlKey) {
 					// Ctrl key means we are zooming.
+					e.preventDefault();
 					performZoom(e.clientX, e.clientY, e.deltaY / 10);
 				} else if (e.shiftKey) {
 					// Shift key means we are panning horizontally.
@@ -258,14 +259,12 @@ function CanvasPane({ loading }: CanvasPaneProps): ReactNode {
 
 	return (
 		<div
+			ref={canvasSpaceRef}
 			className="flex relative justify-center items-center flex-[3] w-full overflow-hidden [&:not(:hover)>#canvas-pointer-marker]:opacity-0 [&:not(:hover)>#canvas-pointer-marker]:transition-opacity [&:not(:hover)>#canvas-pointer-marker]:duration-200 [&:hover>#canvas-pointer-marker]:absolute [&:hover>#canvas-pointer-marker]:border-[3px] [&:hover>#canvas-pointer-marker]:border-black [&:hover>#canvas-pointer-marker]:outline [&:hover>#canvas-pointer-marker]:outline-[1px] [&:hover>#canvas-pointer-marker]:outline-white [&:hover>#canvas-pointer-marker]:outline-offset-[-3px] [&:hover>#canvas-pointer-marker]:pointer-events-none"
 			data-testid="canvas-pane"
 		>
 			{(mode === "brush" || mode == "eraser") && (
-				<CanvasPointerMarker
-					canvasSpaceReference={canvasSpaceRef}
-					shiftKey={shiftKey}
-				/>
+				<CanvasPointerMarker canvasSpaceReference={canvasSpaceRef} />
 			)}
 			<MemoizedDrawingToolbar />
 

--- a/src/components/CanvasPointerMarker/CanvasPointerMarker.tsx
+++ b/src/components/CanvasPointerMarker/CanvasPointerMarker.tsx
@@ -2,14 +2,14 @@
 import { useState, useEffect, useRef } from "react";
 import useStore from "@/state/hooks/useStore";
 import { useShallow } from "zustand/react/shallow";
-import * as Utils from "@/lib/utils";
+
 
 // Types
 import type { ReactNode, RefObject } from "react";
 import type { Coordinates } from "@/types";
 
 type CanvasPointerMarker = {
-	canvasSpaceReference: RefObject<HTMLDivElement | null>;
+	canvasSpaceReference: RefObject<HTMLCanvasElement | null>;
 };
 
 function CanvasPointerMarker({

--- a/src/components/CanvasPointerMarker/CanvasPointerMarker.tsx
+++ b/src/components/CanvasPointerMarker/CanvasPointerMarker.tsx
@@ -10,24 +10,19 @@ import type { Coordinates } from "@/types";
 
 type CanvasPointerMarker = {
 	canvasSpaceReference: RefObject<HTMLDivElement | null>;
-	shiftKey: boolean;
 };
 
 function CanvasPointerMarker({
-	canvasSpaceReference,
-	shiftKey
+	canvasSpaceReference
 }: CanvasPointerMarker): ReactNode {
-	const { mode, scale, strokeWidth, deleteElement } = useStore(
+	const { scale, strokeWidth } = useStore(
 		useShallow((state) => ({
-			mode: state.mode,
 			scale: state.scale,
-			strokeWidth: state.strokeWidth,
-			deleteElement: state.deleteElement
+			strokeWidth: state.strokeWidth
 		}))
 	);
 	const ref = useRef<HTMLDivElement>(null);
 	const [position, setPosition] = useState<Coordinates>({ x: 0, y: 0 });
-	const [isVisible, setIsVisible] = useState<boolean>(false);
 
 	const POINTER_SIZE = strokeWidth * scale;
 
@@ -35,16 +30,8 @@ function CanvasPointerMarker({
 		const canvasSpace = canvasSpaceReference.current;
 		if (!canvasSpace) return;
 
-		const hoveringOverSpace = (e: MouseEvent) =>
-			e.target === canvasSpace || canvasSpace.contains(e.target as Node);
 		function computeCoordinates(e: MouseEvent) {
 			if (!canvasSpace) return;
-
-			if (hoveringOverSpace(e)) {
-				setIsVisible(true);
-			} else {
-				setIsVisible(false);
-			}
 
 			const { left, top, width, height } = canvasSpace.getBoundingClientRect();
 			let newX;
@@ -83,38 +70,7 @@ function CanvasPointerMarker({
 		return () => {
 			document.removeEventListener("mousemove", computeCoordinates);
 		};
-	}, [canvasSpaceReference, POINTER_SIZE]);
-
-	useEffect(() => {
-		const canvasSpace = canvasSpaceReference.current;
-
-		if (!canvasSpace) return;
-
-		const isIntersecting = (e: MouseEvent) => {
-			const m = ref.current;
-
-			if (!m) return;
-
-			const elements = document.getElementsByClassName("element");
-
-			for (let i = 0; i < elements.length; i++) {
-				const node = elements[i];
-				if (
-					Utils.isRectIntersecting(m, node) &&
-					mode === "eraser" &&
-					e.buttons === 1
-				) {
-					deleteElement((element) => element.id === node.id);
-				}
-			}
-		};
-
-		canvasSpace.addEventListener("mousemove", isIntersecting);
-
-		return () => {
-			canvasSpace.removeEventListener("mousemove", isIntersecting);
-		};
-	}, [deleteElement, mode, canvasSpaceReference]);
+	}, [POINTER_SIZE, canvasSpaceReference]);
 
 	return (
 		<div
@@ -126,11 +82,11 @@ function CanvasPointerMarker({
 				borderRadius: "50%",
 				left: -POINTER_SIZE,
 				top: -POINTER_SIZE,
-				display: isVisible && !shiftKey ? "block" : "none",
 				transform: `translate(${position.x}px, ${position.y}px)`,
 				zIndex: 100,
 				width: POINTER_SIZE,
-				height: POINTER_SIZE
+				height: POINTER_SIZE,
+				position: "absolute"
 			}}
 		/>
 	);

--- a/src/components/DrawingToolbar/DrawingToolbar.tsx
+++ b/src/components/DrawingToolbar/DrawingToolbar.tsx
@@ -154,7 +154,7 @@ function DrawingToolbar(): ReactNode {
 
 	return (
 		<div
-			className="flex items-center justify-center text-center absolute top-[10px] w-[80%] min-w-0 min-h-[46px] rounded-[25px] bg-[#303744] shadow-[0_0_10px_rgba(0,0,0,0.5)] p-[0.5em_1.5em] overflow-auto z-[100] pointer-events-none [&>*]:pointer-events-auto"
+		className="flex items-center justify-center text-center absolute top-[10px] w-[80%] min-w-0 min-h-[46px] rounded-[25px] bg-[#303744] shadow-[0_0_10px_rgba(0,0,0,0.5)] p-[0.5em_1.5em] overflow-auto z-[100] pointer-events-none [&>*]:pointer-events-auto"
 			data-testid="drawing-toolbar"
 			role="toolbar"
 			onMouseDown={stopPropagation}

--- a/src/components/DrawingToolbar/DrawingToolbar.tsx
+++ b/src/components/DrawingToolbar/DrawingToolbar.tsx
@@ -1,22 +1,22 @@
 // Lib
 import { SHAPES } from "@/state/store";
-import { memo, Fragment } from "react";
+import { memo, Fragment, useCallback } from "react";
 import useStore from "@/state/hooks/useStore";
 import { useShallow } from "zustand/react/shallow";
 import cn from "@/lib/tailwind-utils";
 
 // Type
-import type { ReactNode, ChangeEvent, MouseEvent, ReactElement } from "react";
+import type { ReactNode, MouseEvent, ReactElement } from "react";
 import type { Shape } from "@/types";
 
 // Components
 import ShapeOption from "@/components/ShapeOption/ShapeOption";
+import DrawingToolbarRangeConfig from "../DrawingToolbarRangeConfig/DrawingToolbarRangeConfig";
 
 // Icons
 import Square from "@/components/icons/Square/Square";
 import Circle from "@/components/icons/Circle/Circle";
 import Triangle from "../icons/Triangle/Triangle";
-import Brush from "../icons/Brush/Brush";
 
 const MemoizedShapeOption = memo(ShapeOption);
 
@@ -30,9 +30,7 @@ function DrawingToolbar(): ReactNode {
 	const {
 		mode,
 		shape,
-		opacity,
 		shapeMode,
-		strokeWidth,
 		changeStrokeWidth,
 		changeOpacity,
 		changeShapeMode
@@ -40,31 +38,12 @@ function DrawingToolbar(): ReactNode {
 		useShallow((state) => ({
 			mode: state.mode,
 			shape: state.shape,
-			opacity: state.opacity,
 			shapeMode: state.shapeMode,
-			strokeWidth: state.strokeWidth,
 			changeStrokeWidth: state.changeStrokeWidth,
 			changeOpacity: state.changeOpacity,
 			changeShapeMode: state.changeShapeMode
 		}))
 	);
-
-	const strengthSettings = {
-		value: strokeWidth,
-		min: 1,
-		max: 100
-	};
-
-	const handleStrengthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const strength = Number(e.target.value);
-
-		changeStrokeWidth(strength);
-	};
-
-	const onOpacityChange = (e: ChangeEvent<HTMLInputElement>) => {
-		const value = Number(e.target.value);
-		changeOpacity(value);
-	};
 
 	const renderedShapes = (
 		<Fragment key="settings_Shapes">
@@ -112,42 +91,33 @@ function DrawingToolbar(): ReactNode {
 	);
 
 	const renderedStrength = (
-		<Fragment key="settings_Strength">
-			<span className="text-sm">Stroke Width</span>
-			<input
-				className="mx-2"
-				name={`${mode}_strength`.toUpperCase()}
-				type="range"
-				min={strengthSettings.min}
-				max={strengthSettings.max}
-				step="1"
-				value={strengthSettings.value}
-				onChange={handleStrengthChange}
-				data-testid="strength-range"
-			/>
-			<span
-				data-testid="strength-value"
-				className="text-sm"
-			>
-				{strengthSettings.value}
-			</span>
-		</Fragment>
+		<DrawingToolbarRangeConfig
+			label="Size"
+			selector={useCallback((state) => state.strokeWidth, [])}
+			type="range"
+			min={1}
+			max={100}
+			step={1}
+			onFinalizedChange={useCallback(
+				(value: number) => changeStrokeWidth(value),
+				[changeStrokeWidth]
+			)}
+		/>
 	);
 
 	const renderedOpacity = (
-		<Fragment key="settings_Brush">
-			<Brush />
-			<input
-				className="mx-2"
-				type="range"
-				id="brush-size"
-				min={0.01}
-				max={1}
-				step={0.01}
-				value={opacity}
-				onChange={onOpacityChange}
-			/>
-		</Fragment>
+		<DrawingToolbarRangeConfig
+			label="Opacity"
+			selector={useCallback((state) => state.opacity, [])}
+			type="range"
+			min={0.01}
+			max={1}
+			step={0.01}
+			onFinalizedChange={useCallback(
+				(value: number) => changeOpacity(value),
+				[changeOpacity]
+			)}
+		/>
 	);
 
 	const additionalSettings: ReactNode[] = [];

--- a/src/components/DrawingToolbarRangeConfig/DrawingToolbarRangeConfig.tsx
+++ b/src/components/DrawingToolbarRangeConfig/DrawingToolbarRangeConfig.tsx
@@ -1,0 +1,94 @@
+// Lib
+import { useState } from "react";
+import useStore from "@/state/hooks/useStore";
+
+// Types
+import type {
+	ChangeEvent,
+	ComponentPropsWithoutRef,
+	KeyboardEvent
+} from "react";
+import type { SliceStores } from "@/types";
+
+// Components
+import Input from "@/components/ui/input";
+
+type DrawingToolbarRangeConfigProps = Omit<
+	ComponentPropsWithoutRef<"input">,
+	"value" | "onChange" | "disabled"
+> & {
+	label: string;
+	selector: (state: SliceStores) => number;
+	onFinalizedChange?: (value: number) => void;
+};
+
+function DrawingToolbarRangeConfig({
+	label,
+	selector,
+	onFinalizedChange,
+	min,
+	max,
+	step,
+	...props
+}: DrawingToolbarRangeConfigProps) {
+	const [configValue, setConfigValue] = useState<number>(useStore(selector));
+	const [isEditing, setIsEditing] = useState<boolean>(false);
+
+	function onDoubleClick() {
+		setIsEditing(true);
+	}
+
+	function onUpdate() {
+		setIsEditing(false);
+		onFinalizedChange?.(configValue);
+	}
+
+	function onEnterPress(e: KeyboardEvent<HTMLInputElement>) {
+		if (e.key === "Enter") {
+			onUpdate();
+		}
+	}
+
+	function onChange(e: ChangeEvent<HTMLInputElement>) {
+		const value = Number(e.target.value);
+		const minNum = Number(min ?? 0);
+		const maxNum = Number(max ?? 100);
+		setConfigValue(Math.max(Math.min(value, maxNum), minNum));
+	}
+
+	return (
+		<>
+			<span className="text-sm">{label}</span>
+			<input
+				className="mx-2"
+				value={configValue}
+				onChange={onChange}
+				onMouseUp={onUpdate}
+				disabled={isEditing}
+				min={min}
+				max={max}
+				step={step}
+				{...props}
+			/>
+			{isEditing ? (
+				<Input
+					className="mx-2 w-12 h-[100%] border-b text-sm outline-none"
+					autoFocus
+					value={configValue}
+					onChange={onChange}
+					onBlur={onUpdate}
+					onKeyDown={onEnterPress}
+				/>
+			) : (
+				<span
+					className="text-sm mx-2"
+					onDoubleClick={onDoubleClick}
+				>
+					{configValue}
+				</span>
+			)}
+		</>
+	);
+}
+
+export default DrawingToolbarRangeConfig;

--- a/src/components/LayerPreview/LayerPreview.tsx
+++ b/src/components/LayerPreview/LayerPreview.tsx
@@ -1,6 +1,7 @@
 // Lib
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import useCanvasRedrawListener from "@/state/hooks/useCanvasRedrawListener";
+import useStore from "@/state/hooks/useStore";
 
 // Types
 import type { ReactNode } from "react";
@@ -15,7 +16,16 @@ const PREVIEW_DRAW = true;
 
 function LayerPreview({ id }: LayerPreviewProps): ReactNode {
 	const previewRef = useRef<HTMLCanvasElement>(null);
+	const drawCanvas = useStore((state) => state.drawCanvas);
 
+	// Initial draw
+	useEffect(() => {
+		const canvas = previewRef.current;
+		if (!canvas) return;
+		drawCanvas(canvas, canvas, { layerId: id, preview: PREVIEW_DRAW });
+	}, [drawCanvas, id]);
+
+	// Then listen for future redraws
 	useCanvasRedrawListener(previewRef, id, DEBOUNCE_REDRAW, PREVIEW_DRAW);
 
 	return (

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -1,9 +1,5 @@
 // Lib
-import ElementsStore from "@/state/stores/ElementsStore";
-import LayersStore from "@/state/stores/LayersStore";
-import { useEffect, useState } from "react";
 import useStore from "@/state/hooks/useStore";
-import { useShallow } from "zustand/react/shallow";
 
 // Types
 import type { ReactNode } from "react";
@@ -13,64 +9,21 @@ import CanvasPane from "@/components/CanvasPane/CanvasPane";
 import LeftToolbar from "@/components/LeftToolbar/LeftToolbar";
 import LayerPane from "@/components/LayerPane/LayerPane";
 import ReferenceWindow from "@/components/ReferenceWindow/ReferenceWindow";
-import { redrawCanvas } from "@/lib/utils";
-import ImageElementStore from "@/state/stores/ImageElementStore";
 
 function Main(): ReactNode {
-	const {
-		setElements,
-		setLayers,
-		refereceWindowEnabled,
-		loadCanvasProperties
-	} = useStore(
-		useShallow((store) => ({
-			setElements: store.setElements,
-			setLayers: store.setLayers,
-			refereceWindowEnabled: store.referenceWindowEnabled,
-			loadCanvasProperties: store.loadCanvasProperties
-		}))
-	);
-	const [loading, setLoading] = useState<boolean>(true);
-
-	useEffect(() => {
-		async function updateLayersAndElements() {
-			const elements = await ElementsStore.getElements();
-			const layers = await LayersStore.getLayers();
-			await ImageElementStore.loadImages();
-			loadCanvasProperties();
-
-			// There must always be at least one layer.
-			// If there are no layers, do not update,
-			// and instead use the default layer state.
-			if (layers.length > 0) {
-				setLayers(
-					layers
-						.sort((a, b) => b[1].position - a[1].position)
-						.map(([id, { name }], i) => ({
-							name,
-							id,
-							active: i === 0,
-							hidden: false
-						}))
-				);
-			}
-			setElements(elements.map(([, element]) => element));
-			setLoading(false);
-			redrawCanvas();
-		}
-
-		updateLayersAndElements();
-	}, [setElements, setLayers, loadCanvasProperties]);
+	const refereceWindowEnabled = useStore(
+    (state) => state.referenceWindowEnabled
+  );
 
 	return (
 		<main
 			id="main-content"
 			data-testid="main-content"
-			className="flex h-[calc(100vh-3rem)] bg-red-600"
+			className="flex h-[calc(100vh-3rem)]"
 		>
 			<LeftToolbar />
 
-			<CanvasPane loading={loading} />
+			<CanvasPane  />
 
 			{/* Reference window */}
 			{refereceWindowEnabled && <ReferenceWindow />}

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -66,7 +66,7 @@ function Main(): ReactNode {
 		<main
 			id="main-content"
 			data-testid="main-content"
-			className="flex h-[calc(100vh-3rem)]"
+			className="flex h-[calc(100vh-3rem)] bg-red-600"
 		>
 			<LeftToolbar />
 

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/components/ui/menubar";
 import NavbarFileSaveStatus from "../NavbarFileSaveStatus/NavbarFileSaveStatus";
 import ImageElementStore from "@/state/stores/ImageElementStore";
+import useStoreContext from "@/state/hooks/useStoreContext";
 
 function Navbar(): ReactNode {
 	const {
@@ -67,6 +68,7 @@ function Navbar(): ReactNode {
 		}))
 	);
 	const { ref } = useCanvasRef();
+  const store = useStoreContext();
 	const downloadRef = useRef<HTMLAnchorElement>(null);
 	const openFileRef = useRef<HTMLInputElement>(null);
 	const [saveStatus, setSaveStatus] = useState<"saving" | "saved" | "error">(
@@ -209,7 +211,7 @@ function Navbar(): ReactNode {
 			await LayersStore.clearStore();
 			await ElementsStore.clearStore();
 			await ImageElementStore.clearStore();
-			window.localStorage.clear();
+      store.persist.clearStorage();
 			resetLayersAndElements(); // Reset the Zustand state.
 
 			// Upload the image.

--- a/src/components/StoreContext/StoreContext.tsx
+++ b/src/components/StoreContext/StoreContext.tsx
@@ -1,11 +1,11 @@
 // Lib
-import { createContext, useRef } from "react";
-import { initializeStore } from "@/state/store";
+import { createContext, useEffect, useRef } from "react";
+import { initializeEditorStore } from "@/state/store";
 
 // Types
 import type { ReactNode } from "react";
 
-type InitStore = ReturnType<typeof initializeStore>;
+type InitStore = ReturnType<typeof initializeEditorStore>;
 
 type StoreProviderProps = Readonly<{
 	store?: InitStore;
@@ -15,11 +15,14 @@ type StoreProviderProps = Readonly<{
 const StoreContext = createContext<InitStore | undefined>(undefined);
 
 function StoreProvider({ store, children }: StoreProviderProps): ReactNode {
-	const storeRef = useRef<InitStore>(null);
+	const storeRef = useRef<InitStore>(store ?? initializeEditorStore());
 
-	if (!storeRef.current) {
-		storeRef.current = store ?? initializeStore();
-	}
+	useEffect(() => {
+		const persist = storeRef.current.persist;
+		if (!persist.hasHydrated()) {
+			persist.rehydrate();
+		}
+	}, []);
 
 	return (
 		<StoreContext.Provider value={storeRef.current}>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,46 @@
+// Lib
+import cn from "@/lib/tailwind-utils";
+
+// Types
+import type { ComponentProps, ReactNode } from "react";
+
+type InputProps = ComponentProps<"input"> & {
+	icon?: ReactNode;
+};
+
+function Input({ className, type, icon, ...props }: InputProps) {
+	if (icon) {
+		return (
+			<div className="relative flex items-center">
+				<span className="absolute left-2 z-10 text-muted-foreground">
+					{icon}
+				</span>
+				<input
+					data-slot="input"
+					className={cn(
+						"file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 pl-8 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+						"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+						"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+						className
+					)}
+					{...props}
+				/>
+			</div>
+		);
+	}
+	return (
+		<input
+			type={type}
+			data-slot="input"
+			className={cn(
+				"file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+				"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+				"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+				className
+			)}
+			{...props}
+		/>
+	);
+}
+
+export default Input;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -224,7 +224,7 @@ function detectOperatingSystem(): OperatingSystem {
 
 /**
  *
- * @param noChange Whether visually, nothing may have no changed.
+ * @param noChange Whether visually, nothing may have not changed.
  */
 function redrawCanvas(noChange: boolean = false) {
 	document.dispatchEvent(

--- a/src/pages/index/index.page.tsx
+++ b/src/pages/index/index.page.tsx
@@ -2,7 +2,7 @@
 import { useEffect } from "react";
 import LayersStore from "@/state/stores/LayersStore";
 import ElementsStore from "@/state/stores/ElementsStore";
-import { initializeStore } from "@/state/store";
+import { initializeEditorStore } from "@/state/store";
 import useInitialEditorState from "@/state/hooks/useInitialEditorState";
 
 // Components
@@ -50,7 +50,7 @@ function Page() {
 	}, []);
 
 	return (
-		<StoreProvider store={initializeStore(state)}>
+		<StoreProvider store={initializeEditorStore(state)}>
 			<CanvasReferenceProvider>
 				<ErrorBoundary>
 					<Navbar />

--- a/src/renderer/_default.page.server.tsx
+++ b/src/renderer/_default.page.server.tsx
@@ -12,7 +12,7 @@ import { escapeInject } from "vite-plugin-ssr/server";
 import logo from "@/assets/icons/IdeaDrawnNewLogo.png";
 import type { PageContextServer } from "./types";
 import { renderToStream } from "react-streaming/server";
-import { initializeStore } from "@/state/store";
+import { initializeEditorStore } from "@/state/store";
 import type { SliceStores } from "@/types";
 import { ThemeProvider } from "@/components/ThemeProvider/ThemeProvider";
 
@@ -22,7 +22,7 @@ async function render(pageContext: PageContextServer) {
 	if (!Page)
 		throw new Error("My render() hook expects pageContext.Page to be defined");
 
-	const store = initializeStore();
+	const store = initializeEditorStore();
 	const preloadedState = store.getState();
 	const stateWithoutFunctions: Partial<SliceStores> = Object.fromEntries(
 		Object.entries(preloadedState).filter(

--- a/src/state/hooks/useCanvasRedrawListener.ts
+++ b/src/state/hooks/useCanvasRedrawListener.ts
@@ -3,7 +3,6 @@ import useStore from "./useStore";
 import useThrottle from "./useThrottle";
 import useDebounceCallback from "./useDebounceCallback";
 import { CanvasRedrawEvent } from "@/types";
-import useCanvasRef from "./useCanvasRef";
 
 const DEBOUNCE_TIME_MS = 500;
 
@@ -26,19 +25,15 @@ function useCanvasRedrawListener(
 	preview: boolean = false
 ): void {
 	const drawCanvas = useStore((state) => state.drawCanvas);
-	const { ref } = useCanvasRef();
 
 	const draw = useCallback(
 		(canvas: HTMLCanvasElement, layerId?: string) => {
-			if (!ref) {
-				throw new Error("Canvas ref does not exist.");
-			}
-			drawCanvas(canvas, ref, { layerId, preview });
+			drawCanvas(canvas, canvas, { layerId, preview });
 			// requestAnimationFrame(() => {
 			// 	draw(canvas, layerId);
 			// });
 		},
-		[drawCanvas, preview, ref]
+		[drawCanvas, preview]
 	);
 
 	const handleCanvasRedraw = useThrottle((e: CanvasRedrawEvent) => {

--- a/src/state/slices/canvasElementsSlice.ts
+++ b/src/state/slices/canvasElementsSlice.ts
@@ -7,7 +7,7 @@ import type {
 	CanvasElementType
 } from "@/types";
 
-type Predicate = (element: CanvasElement) => boolean;
+type Predicate<A> = (arg: A) => boolean;
 
 export const createCanvasElementsSlice: StateCreator<
 	SliceStores,
@@ -56,7 +56,7 @@ export const createCanvasElementsSlice: StateCreator<
 
 	function changeElementProperties(
 		callback: (el: CanvasElement) => CanvasElement,
-		predicate: Predicate
+		predicate: Predicate<CanvasElement>
 	) {
 		const elements = get().elements;
 		const newElements = elements.map((element) => {
@@ -80,7 +80,7 @@ export const createCanvasElementsSlice: StateCreator<
 		});
 	}
 
-	function deleteElement(predicate: Predicate) {
+	function deleteElement(predicate: Predicate<CanvasElement>) {
 		const deletedIds: string[] = [];
 		set((state) => ({
 			elements: state.elements.filter((element) => {
@@ -99,7 +99,7 @@ export const createCanvasElementsSlice: StateCreator<
 		set({ elements });
 	}
 
-	function copyElement(predicate: Predicate) {
+	function copyElement(predicate: Predicate<CanvasElement>) {
 		const elements = get().elements;
 		const copiedElements = elements.filter((element) => predicate(element));
 		set({ copiedElements });

--- a/src/state/slices/canvasElementsSlice.ts
+++ b/src/state/slices/canvasElementsSlice.ts
@@ -43,7 +43,7 @@ export const createCanvasElementsSlice: StateCreator<
 			layerId: layer.id,
 			...properties, // Override the default properties with the provided properties, if any.
 			drawType: shapeMode,
-			strokeWidth,
+			strokeWidth: Math.max(1, strokeWidth),
 			opacity: type === "eraser" ? 1 : opacity
 		};
 

--- a/src/state/slices/canvasSlice.ts
+++ b/src/state/slices/canvasSlice.ts
@@ -537,11 +537,16 @@ export const createCanvasSlice: StateCreator<
 				case "brush":
 				case "eraser": {
 					ctx.beginPath();
-					for (const point of element.path) {
+					for (let i = 0; i < element.path.length; i++) {
+						const point = element.path[i];
 						if (point.startingPoint) {
 							ctx.moveTo(point.x, point.y);
 						} else {
-							ctx.lineTo(point.x, point.y);
+							const lastPoint = element.path[i - 1];
+							// Add a quadratic curve for smoother lines
+							const midX = (lastPoint.x + point.x) / 2;
+							const midY = (lastPoint.y + point.y) / 2;
+							ctx.quadraticCurveTo(lastPoint.x, lastPoint.y, midX, midY);
 						}
 					}
 					ctx.stroke();

--- a/src/state/slices/canvasSlice.ts
+++ b/src/state/slices/canvasSlice.ts
@@ -473,7 +473,10 @@ export const createCanvasSlice: StateCreator<
 			width: canvasWidth,
 			height: canvasHeight,
 			position: { x: posX, y: posY },
-			scale
+			scale,
+			opacity,
+			strokeWidth,
+			color
 		} = get();
 
 		if (layers.length === 0) {
@@ -637,6 +640,16 @@ export const createCanvasSlice: StateCreator<
 		);
 
 		ctx.restore();
+
+		// After drawing everything, reset the styles back to the current settings
+		// if not in preview mode. This is for the main canvas where the user draws,
+		// and we want to keep style settings persistent.
+		if (!options?.preview) {
+			ctx.globalAlpha = opacity;
+			ctx.strokeStyle = color;
+			ctx.fillStyle = color;
+			ctx.lineWidth = strokeWidth;
+		}
 	}
 
 	function resetLayersAndElements() {

--- a/src/state/slices/canvasSlice.ts
+++ b/src/state/slices/canvasSlice.ts
@@ -10,8 +10,7 @@ import type {
 	Shape,
 	SliceStores,
 	DrawOptions,
-	CanvasElement,
-	CanvasState
+	CanvasElement
 } from "@/types";
 import * as Utils from "@/lib/utils";
 import ImageElementStore from "../stores/ImageElementStore";
@@ -247,21 +246,6 @@ export const createCanvasSlice: StateCreator<
 		return { layers, elements };
 	}
 
-	function loadCanvasProperties() {
-		const str = window.localStorage.getItem("canvas-properties");
-
-		if (!str) {
-			console.warn("Cannot load 'canvas-properties'");
-			return;
-		}
-
-		const { width, height, background } = JSON.parse(str) as Pick<
-			CanvasState,
-			"width" | "height" | "background"
-		>;
-		set({ width, height, background });
-	}
-
 	/**
 	 * A helper function that returns an array of lines of the given text that fit within the given width.
 	 * @param text The text to split into lines.
@@ -467,7 +451,6 @@ export const createCanvasSlice: StateCreator<
 		const {
 			mode,
 			elements,
-			background,
 			layers,
 			width: canvasWidth,
 			height: canvasHeight,
@@ -628,12 +611,7 @@ export const createCanvasSlice: StateCreator<
 		}
 
 		// Finally, draw the paper canvas (background)
-		drawPaperCanvas(
-			ctx,
-			0,
-			0,
-			options?.preview
-		);
+		drawPaperCanvas(ctx, 0, 0, options?.preview);
 
 		ctx.restore();
 
@@ -647,6 +625,7 @@ export const createCanvasSlice: StateCreator<
 			ctx.lineWidth = strokeWidth;
 			ctx.globalCompositeOperation =
 				mode === "eraser" ? "destination-out" : "source-over";
+			ctx.lineCap = "round";
 		}
 	}
 
@@ -697,7 +676,6 @@ export const createCanvasSlice: StateCreator<
 		changeX,
 		changeY,
 		prepareForSave,
-		loadCanvasProperties,
 		prepareForExport,
 		toggleReferenceWindow,
 		getPointerPosition,

--- a/src/state/slices/canvasSlice.ts
+++ b/src/state/slices/canvasSlice.ts
@@ -417,11 +417,9 @@ export const createCanvasSlice: StateCreator<
 		ctx: CanvasRenderingContext2D,
 		x: number,
 		y: number,
-		width: number,
-		height: number,
-		background: string,
 		preview: boolean = false
 	) {
+		const { width, height, background } = get();
 		ctx.beginPath();
 		ctx.rect(x, y, width, height);
 		ctx.globalCompositeOperation = "destination-over";
@@ -467,6 +465,7 @@ export const createCanvasSlice: StateCreator<
 		options?: DrawOptions
 	) {
 		const {
+			mode,
 			elements,
 			background,
 			layers,
@@ -633,9 +632,6 @@ export const createCanvasSlice: StateCreator<
 			ctx,
 			0,
 			0,
-			canvasWidth,
-			canvasHeight,
-			background,
 			options?.preview
 		);
 
@@ -649,6 +645,8 @@ export const createCanvasSlice: StateCreator<
 			ctx.strokeStyle = color;
 			ctx.fillStyle = color;
 			ctx.lineWidth = strokeWidth;
+			ctx.globalCompositeOperation =
+				mode === "eraser" ? "destination-out" : "source-over";
 		}
 	}
 
@@ -705,6 +703,7 @@ export const createCanvasSlice: StateCreator<
 		getPointerPosition,
 		isCanvasOffscreen,
 		centerCanvas,
+		drawPaperCanvas,
 		drawCanvas,
 		resetLayersAndElements
 	};

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -3,17 +3,20 @@ import { subscribeWithSelector } from "zustand/middleware";
 import { createCanvasSlice } from "./slices/canvasSlice";
 import { createHistorySlice } from "./slices/historySlice";
 import { createCanvasElementsSlice } from "./slices/canvasElementsSlice";
+import { persist } from "zustand/middleware";
 
 import type { Modes, Shapes, SliceStores } from "../types";
 
-export type Store = ReturnType<typeof initializeStore>;
+export type Store = ReturnType<typeof initializeEditorStore>;
 
 /**
  * Creates a Zustand store that combines the canvas, history, and canvas elements slices.
  * @param preloadedState The preloaded state to initialize the store with.
  * @returns A Zustand store.
  */
-export function initializeStore(preloadedState: Partial<SliceStores> = {}) {
+export function initializeEditorStore(
+	preloadedState: Partial<SliceStores> = {}
+) {
 	// `structuredClone` throws an error if the object contains functions as
 	// functions are not serializable. We need to remove the functions from the
 	// preloaded state before passing it to `structuredClone`.
@@ -24,19 +27,34 @@ export function initializeStore(preloadedState: Partial<SliceStores> = {}) {
 	);
 
 	return createStore<SliceStores>()(
-		subscribeWithSelector((...a) => ({
-			...createCanvasSlice(...a),
-			...createHistorySlice(...a),
-			...createCanvasElementsSlice(...a),
-			// We want to call structuredClone on the preloadedState to ensure that it is a deep clone.
-			// This ensures that the preloadedState is not mutated when the store is initialized.
-			// This is beneficial for testing purposes, but also ensures that the preloadedState is not mutated
-			// when the store is initialized.
-			...preloadedState, // spread the state to pass the functions, if any.
-			// Spread the state without functions to ensure that the functions are not serialized and
-			// the values are not mutated.
-			...structuredClone(stateWithoutFunctions)
-		}))
+		subscribeWithSelector(
+			persist(
+				(...a) => ({
+					...createCanvasSlice(...a),
+					...createHistorySlice(...a),
+					...createCanvasElementsSlice(...a),
+					// We want to call structuredClone on the preloadedState to ensure that it is a deep clone.
+					// This ensures that the preloadedState is not mutated when the store is initialized.
+					// This is beneficial for testing purposes, but also ensures that the preloadedState is not mutated
+					// when the store is initialized.
+					...preloadedState, // spread the state to pass the functions, if any.
+					// Spread the state without functions to ensure that the functions are not serialized and
+					// the values are not mutated.
+					...structuredClone(stateWithoutFunctions)
+				}),
+				{
+					name: "live-canvas-store",
+					partialize: (state) => ({
+						width: state.width,
+						height: state.height,
+						position: state.position,
+						scale: state.scale
+					}),
+					// Need to skip hydration to avoid using browser-only APIs during SSR.
+					skipHydration: true
+				}
+			)
+		)
 	);
 }
 

--- a/src/state/stores/ImageElementStore.ts
+++ b/src/state/stores/ImageElementStore.ts
@@ -75,11 +75,11 @@ export default class ImageElementStore extends BaseStore {
 	}
 
 	public static openStore() {
-		this.open();
+		return this.open();
 	}
 
 	public static closeStore() {
-		this.close();
+		return this.close();
 	}
 
 	public static clearStore() {

--- a/src/tests/test-utils.tsx
+++ b/src/tests/test-utils.tsx
@@ -11,7 +11,7 @@ import type { Store } from "@/state/store";
 import { render, renderHook } from "@testing-library/react";
 import { StoreProvider } from "@/components/StoreContext/StoreContext";
 
-import { initializeStore } from "@/state/store";
+import { initializeEditorStore } from "@/state/store";
 import { ThemeProvider } from "@/components/ThemeProvider/ThemeProvider";
 
 type ExtendedRenderOptions = Omit<RenderOptions, "queries"> & {
@@ -35,7 +35,7 @@ export function renderWithProviders(
 	ui: ReactNode,
 	{
 		preloadedState = {},
-		store = initializeStore(preloadedState),
+		store = initializeEditorStore(preloadedState),
 		...renderOptions
 	}: ExtendedRenderOptions = {}
 ): RenderResult {
@@ -58,7 +58,7 @@ export function renderHookWithProviders<Result, Props>(
 	hook: (props: Props) => Result,
 	{
 		preloadedState = {},
-		store = initializeStore(preloadedState),
+		store = initializeEditorStore(preloadedState),
 		...renderOptions
 	}: ExtendedRenderHookOptions<Props> = {}
 ): RenderHookResult<Result, Props> {

--- a/src/types/Slices.types.ts
+++ b/src/types/Slices.types.ts
@@ -86,6 +86,12 @@ export type CanvasStore = CanvasState & {
 		top: boolean;
 	};
 	centerCanvas: (ref: HTMLCanvasElement) => void;
+	drawPaperCanvas: (
+		ctx: CanvasRenderingContext2D,
+		x: number,
+		y: number,
+		preview?: boolean
+	) => void;
 	resetLayersAndElements: () => void;
 };
 

--- a/src/types/Slices.types.ts
+++ b/src/types/Slices.types.ts
@@ -65,7 +65,6 @@ export type CanvasStore = CanvasState & {
 	changeY: (payload: number) => void;
 	toggleReferenceWindow: () => void;
 	prepareForSave: () => SavedCanvasProperties;
-	loadCanvasProperties: () => void;
 	prepareForExport: (ref: HTMLCanvasElement, quality?: number) => Promise<Blob>;
 	drawCanvas: (
 		baseCanvas: HTMLCanvasElement,


### PR DESCRIPTION
### Description

Includes a few fixes and improvements. Several include:
- Ability to edit sliders in the Drawing Toolbar by double-clicking the numerical value displayed next to the slider and typing a value
- Fix eraser tool
- Fix layer previews not drawing the preview on page load
- Ability to persist the canvas position and scaling across browser sessions
- Ability to draw smoother brush strokes using the `quadraticCurveTo(...)` HTML5 Canvas API

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes changes to existing functionality, possibly impacting existing features)

## Have you tested your changes?
- [ ] I wrote tests for the code I've written.